### PR TITLE
first commit with working code

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -1,0 +1,37 @@
+package main
+
+import (
+	"fmt"
+	"net/http"
+	"os"
+
+	"github.com/mhrivnak/netbox-isolator/pkg/client"
+	"github.com/mhrivnak/netbox-isolator/pkg/handlers"
+)
+
+func main() {
+	for _, envvar := range []string{"NETBOX_URL", "NETBOX_TOKEN"} {
+		if os.Getenv(envvar) == "" {
+			fmt.Printf("%s environment variable is not set\n", envvar)
+			os.Exit(1)
+		}
+	}
+
+	url := os.Getenv("NETBOX_URL")
+	token := os.Getenv("NETBOX_TOKEN")
+
+	c, err := client.New(url, token)
+	if err != nil {
+		fmt.Println(err.Error())
+		os.Exit(1)
+	}
+	h := handlers.New(c)
+
+	http.HandleFunc("/api/devices/", h.Device)
+	fmt.Println("Listening on port 8080")
+	err = http.ListenAndServe(":8080", nil)
+	if err != nil {
+		fmt.Println(err.Error())
+		os.Exit(1)
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/mhrivnak/netbox-isolator
+
+go 1.23.8

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -1,0 +1,198 @@
+package client
+
+import (
+	"bytes"
+	"crypto/tls"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+
+	"github.com/mhrivnak/netbox-isolator/pkg/types"
+)
+
+type Client interface {
+	GetInterface(u string) (*types.Interface, error)
+	GetInterfacesByDevice(ID int) ([]types.Interface, error)
+	PatchInterfaceVLAN(i *types.Interface, vlanID int) error
+	GetVLANByTenant(tenantID int) (*types.VLAN, error)
+}
+
+func New(apiurl, token string) (Client, error) {
+	tr := &http.Transport{
+		TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+	}
+
+	parsed, err := url.Parse(apiurl)
+	if err != nil {
+		return nil, err
+	}
+
+	return &client{
+		client:    &http.Client{Transport: tr},
+		url:       apiurl,
+		parsedURL: parsed,
+		token:     token,
+	}, nil
+}
+
+type client struct {
+	url       string
+	parsedURL *url.URL
+	token     string
+	client    *http.Client
+}
+
+func (c *client) send(req *http.Request) (*http.Response, error) {
+	req.Header.Set("Authorization", fmt.Sprintf("Token %s", c.token))
+	return c.client.Do(req)
+}
+
+func (c *client) patch(u string, data []byte) (*http.Response, error) {
+	parsed, err := url.Parse(u)
+	if err != nil {
+		return nil, err
+	}
+
+	apiurl := c.parsedURL.ResolveReference(parsed)
+
+	req, err := http.NewRequest("PATCH", apiurl.String(), bytes.NewBuffer(data))
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+
+	fmt.Println("PATCH:", apiurl.String())
+	resp, err := c.send(req)
+	if err != nil {
+		return nil, err
+	}
+
+	if resp.StatusCode < 200 || resp.StatusCode > 299 {
+		fmt.Printf("PATCH got response code %d\n", resp.StatusCode)
+		return nil, fmt.Errorf("http status code %d", resp.StatusCode)
+	}
+	return resp, nil
+}
+
+func (c *client) get(u string) (*http.Response, error) {
+	parsed, err := url.Parse(u)
+	if err != nil {
+		return nil, err
+	}
+
+	apiurl := c.parsedURL.ResolveReference(parsed)
+
+	req, err := http.NewRequest("GET", apiurl.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	fmt.Println("GET:", apiurl.String())
+	resp, err := c.send(req)
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("status code %d", resp.StatusCode)
+	}
+	return resp, err
+}
+
+// GetInterfacesByDevice retrieves a list of network interfaces associated with
+// the specified device ID. It returns a slice of Interface objects if
+// successful, or an error if any issues occur during the HTTP GET request or
+// JSON decoding of the response.
+func (c *client) GetInterfacesByDevice(deviceID int) ([]types.Interface, error) {
+	path := fmt.Sprintf("api/dcim/interfaces/?device_id=%d", deviceID)
+
+	resp, err := c.get(path)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	var interfaceList types.InterfaceList
+	err = json.NewDecoder(resp.Body).Decode(&interfaceList)
+	if err != nil {
+		return nil, err
+	}
+
+	return interfaceList.Results, nil
+}
+
+// GetInterface retrieves a network interface from the given URL. It returns a
+// pointer to the Interface object if successful, or an error if any issues
+// occur during the HTTP GET request or JSON decoding of the response.
+func (c *client) GetInterface(u string) (*types.Interface, error) {
+	resp, err := c.get(u)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	var i types.Interface
+	err = json.NewDecoder(resp.Body).Decode(&i)
+	if err != nil {
+		return nil, err
+	}
+
+	return &i, nil
+}
+
+// PatchInterfaceVLAN updates the untagged VLAN of the specified network
+// interface to the provided VLAN ID. It constructs a patch request and sends it
+// to the interface's URL. If successful, it returns nil. Otherwise, it returns
+// an error if there are issues during JSON marshalling, HTTP request creation,
+// or response handling.
+func (c *client) PatchInterfaceVLAN(i *types.Interface, vlanID int) error {
+	patch := types.InterfaceVLANPatch{
+		UntaggedVLAN: types.ObjectRef{
+			ID: vlanID,
+		},
+	}
+
+	data, err := json.Marshal(patch)
+	if err != nil {
+		return err
+	}
+
+	resp, err := c.patch(i.URL, data)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	return nil
+}
+
+// GetVLANByTenant retrieves a VLAN that is assigned to the given tenant ID. It
+// returns a pointer to the VLAN object if successful, or an error if any issues
+// occur during the HTTP GET request or JSON decoding of the response. It will
+// return an error if there is not exactly one VLAN for the given tenant ID.
+func (c *client) GetVLANByTenant(tenantID int) (*types.VLAN, error) {
+	path := fmt.Sprintf("api/ipam/vlans/?tenant_id=%d", tenantID)
+
+	resp, err := c.get(path)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	var vlanList types.VLANList
+	err = json.NewDecoder(resp.Body).Decode(&vlanList)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(vlanList.Results) == 0 {
+		return nil, fmt.Errorf("no VLANs found for tenant %d", tenantID)
+	}
+
+	if len(vlanList.Results) > 1 {
+		return nil, fmt.Errorf("multiple VLANs found for tenant %d", tenantID)
+	}
+
+	return &vlanList.Results[0], nil
+}

--- a/pkg/handlers/handler.go
+++ b/pkg/handlers/handler.go
@@ -1,0 +1,83 @@
+package handlers
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"github.com/mhrivnak/netbox-isolator/pkg/client"
+	"github.com/mhrivnak/netbox-isolator/pkg/types"
+)
+
+type Handlers struct {
+	client client.Client
+}
+
+func New(client client.Client) *Handlers {
+	return &Handlers{
+		client: client,
+	}
+}
+
+func (h *Handlers) Device(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	// decode the body into a device webhook struct
+	var deviceWH types.DeviceWebhook
+	err := json.NewDecoder(r.Body).Decode(&deviceWH)
+	if err != nil {
+		fmt.Println(err.Error())
+		http.Error(w, "Failed to decode request body", http.StatusBadRequest)
+		return
+	}
+
+	w.WriteHeader(http.StatusAccepted)
+
+	fmt.Printf("Device webhook: %+v\n", deviceWH)
+
+	if deviceWH.Data.Tenant == nil {
+		fmt.Println("device has no tenant")
+		return
+	}
+
+	// get VLAN assigned to the device's tenant
+	tenantVLAN, err := h.client.GetVLANByTenant(deviceWH.Data.Tenant.ID)
+	if err != nil {
+		fmt.Println("could not find a VLAN for the device's tenant")
+		fmt.Println(err.Error())
+		return
+	}
+
+	// get interfaces on the device
+	interfaces, err := h.client.GetInterfacesByDevice(deviceWH.Data.ID)
+	if err != nil {
+		fmt.Println(err.Error())
+		return
+	}
+
+	// for each interface, get the interface on the other end (the switch) and
+	// make sure it's assigned to the tenant's VLAN
+	for _, i := range interfaces {
+		for _, e := range i.ConnectedEndpoints {
+			// get endpoint
+			switchIface, err := h.client.GetInterface(e.URL)
+			if err != nil {
+				fmt.Println(err.Error())
+				return
+			}
+
+			// update if needed
+			if switchIface.UntaggedVLAN == nil || switchIface.UntaggedVLAN.ID != tenantVLAN.ID {
+				err := h.client.PatchInterfaceVLAN(switchIface, tenantVLAN.ID)
+				if err != nil {
+					fmt.Println(err.Error())
+				} else {
+					fmt.Printf("Updated interface %s to VLAN %d\n", switchIface.Name, tenantVLAN.ID)
+				}
+			}
+		}
+	}
+}

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -1,0 +1,61 @@
+package types
+
+type ObjectRef struct {
+	ID int `json:"id"`
+}
+
+type WebhookBody struct {
+	Event string `json:"event"`
+	Model string `json:"model"`
+}
+
+type DeviceWebhook struct {
+	WebhookBody
+	Data Device `json:"data"`
+}
+
+type Tenant struct {
+	ID   int    `json:"id"`
+	Name string `json:"name"`
+	URL  string `json:"url"`
+}
+
+type Device struct {
+	ID     int     `json:"id"`
+	Name   string  `json:"name"`
+	URL    string  `json:"url"`
+	Tenant *Tenant `json:"tenant,omitempty"`
+}
+
+type Interface struct {
+	ID                 int                 `json:"id"`
+	Name               string              `json:"name"`
+	URL                string              `json:"url"`
+	ConnectedEndpoints []ConnectedEndpoint `json:"connected_endpoints"`
+	UntaggedVLAN       *VLAN               `json:"untagged_vlan,omitempty"`
+}
+
+type InterfaceVLANPatch struct {
+	UntaggedVLAN ObjectRef `json:"untagged_vlan"`
+}
+
+type ConnectedEndpoint struct {
+	ID   int    `json:"id"`
+	Name string `json:"name"`
+	URL  string `json:"url"`
+}
+
+type InterfaceList struct {
+	Results []Interface `json:"results"`
+}
+
+type VLAN struct {
+	ID   int    `json:"id"`
+	Name string `json:"name"`
+	URL  string `json:"url"`
+	VID  int    `json:"vid"`
+}
+
+type VLANList struct {
+	Results []VLAN `json:"results"`
+}


### PR DESCRIPTION
This receives webhook notifications from netbox when a Device changes. It finds the tenant that the Device is assigned to and ensures that any switch ports that the device is connected to are set as access ports for that VLAN.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced an HTTP API server listening on port 8080 with a `/api/devices/` endpoint to handle device webhook POST requests.
  - Requires environment variables for configuration.
  - Supports automatic VLAN assignment to switch interfaces based on device tenant information.
- **Chores**
  - Added initial project setup including module definition and structured data types for devices, interfaces, VLANs, and tenants.
  - Implemented a client interface for interacting with the network management API.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->