### PR TITLE
adds a /status endpoint to check service status

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -28,6 +28,7 @@ func main() {
 	h := handlers.New(c)
 
 	http.HandleFunc("/api/devices/", h.Device)
+	http.HandleFunc("/status", handlers.Status)
 	fmt.Println("Listening on port 8080")
 	err = http.ListenAndServe(":8080", nil)
 	if err != nil {

--- a/pkg/handlers/status.go
+++ b/pkg/handlers/status.go
@@ -1,0 +1,16 @@
+package handlers
+
+import "net/http"
+
+// Status returns a 200 OK response.
+func Status(w http.ResponseWriter, r *http.Request) {
+	switch r.Method {
+	case http.MethodGet:
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("OK"))
+	case http.MethodHead:
+		w.WriteHeader(http.StatusOK)
+	default:
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+	}
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a new "/status" endpoint that allows users to check the server status. Responds with "OK" for GET requests and a 200 OK status for HEAD requests. Other methods receive a 405 Method Not Allowed response.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->